### PR TITLE
fix: add -timeout-cron suffix to cronjob resource

### DIFF
--- a/chart/templates/timeoutCron.yaml
+++ b/chart/templates/timeoutCron.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "corndogs.fullname" . }}
+  name: {{ include "corndogs.fullname" . }}-timeout-cron
 spec:
   schedule: {{ .Values.timeoutCron.schedule | quote }}
   concurrencyPolicy: Forbid


### PR DESCRIPTION
without this, pods that get created by the cronjob are just named "corndogs" which is the same as the corndogs service, which is confusing.